### PR TITLE
chore: update version to 15.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-script-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Script Plugin</name>
-	<version>15.1.0-SNAPSHOT</version>
+	<version>15.2.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-script-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-script-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Updated project version from 15.1.0 to 15.2.0-SNAPSHOT in preparation for the next release cycle.

## Changes Made
- Updated `version` in pom.xml from 15.1.0-SNAPSHOT to 15.2.0-SNAPSHOT
- Updated parent `fess-parent` version from 15.1.0 to 15.2.0

## Testing
No additional testing required as this is a version number update only.

## Breaking Changes
None. This is a routine version bump for development purposes.

## Additional Notes
This version update aligns the project with the latest Fess parent version and prepares for the next development cycle.