### PR TITLE
chore: update version to 15.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-script-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Script Plugin</name>
-	<version>15.2.0-SNAPSHOT</version>
+	<version>15.3.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-script-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-script-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0</version>
+		<version>15.3.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

This PR updates the project version to align with the latest Fess framework release 15.3.0.

## Changes Made

- Update project version from `15.2.0-SNAPSHOT` to `15.3.0-SNAPSHOT`
- Update parent POM version from `15.2.0` to `15.3.0`

## Testing

- Version numbers verified in `pom.xml`
- No functional changes, build should pass as-is

## Breaking Changes

None

## Additional Notes

This is a routine version bump to keep the plugin synchronized with the Fess framework release cycle.