### PR TITLE
chore: update version to 15.4.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>fess-script-example</artifactId>
 	<packaging>jar</packaging>
 	<name>Example Script Plugin</name>
-	<version>15.3.0-SNAPSHOT</version>
+	<version>15.4.0-SNAPSHOT</version>
 	<scm>
 		<connection>scm:git:git@github.com:codelibs/fess-script-example.git</connection>
 		<developerConnection>scm:git:git@github.com:codelibs/fess-script-example.git</developerConnection>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.3.0</version>
+		<version>15.4.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

Update project version to 15.4.0-SNAPSHOT for the next development cycle.

## Changes Made

- Update project artifact version from 15.3.0-SNAPSHOT to 15.4.0-SNAPSHOT
- Update fess-parent POM version from 15.3.0 to 15.4.0

## Testing

No testing required - version bump only.

## Breaking Changes

None.